### PR TITLE
Add option to use WrenchStamped messages in lib and use it in node

### DIFF
--- a/include/wrench_marker/wrench_marker.h
+++ b/include/wrench_marker/wrench_marker.h
@@ -13,7 +13,7 @@
 #define WRENCH_MARKER_WRENCH_MARKER_H
 
 #include <visualization_msgs/MarkerArray.h>
-#include <geometry_msgs/Wrench.h>
+#include <geometry_msgs/WrenchStamped.h>
 #include <geometry_msgs/Point.h>
 
 namespace wrench_marker
@@ -32,9 +32,11 @@ class WrenchMarker
 
 public:
 
-  WrenchMarker( const std::string& frame, const std::string& ns = "wrench", visualization_msgs::MarkerArray* msg = 0 );
+  WrenchMarker( const std::string& ns = "wrench", visualization_msgs::MarkerArray* msg = 0 );
 
-  const visualization_msgs::MarkerArray& populate( const geometry_msgs::Wrench& wrench, const ros::Time& time = ros::Time::now(), const geometry_msgs::Point& pos = geometry_msgs::Point() );
+  const visualization_msgs::MarkerArray& getMarker( const geometry_msgs::WrenchStamped& wrench_stamped, const ros::Time& time = ros::Time::now() );
+
+  const visualization_msgs::MarkerArray& getMarker( const geometry_msgs::Wrench& wrench, const std::string& frame, const geometry_msgs::Point& pos = geometry_msgs::Point(), const ros::Time& time = ros::Time::now() );
 
 private:
 

--- a/src/wrench_marker.cpp
+++ b/src/wrench_marker.cpp
@@ -14,7 +14,7 @@
 namespace wrench_marker
 {
 
-WrenchMarker::WrenchMarker( const std::string& frame, const std::string& ns, visualization_msgs::MarkerArray* msg )
+WrenchMarker::WrenchMarker( const std::string& ns, visualization_msgs::MarkerArray* msg )
   : msg_( msg )
 {
 
@@ -28,7 +28,6 @@ WrenchMarker::WrenchMarker( const std::string& frame, const std::string& ns, vis
   }
 
   visualization_msgs::Marker aux_marker;
-  aux_marker.header.frame_id = frame;
   aux_marker.ns = ns;
   aux_marker.id = 0;
   aux_marker.type = visualization_msgs::Marker::ARROW;
@@ -71,10 +70,18 @@ WrenchMarker::WrenchMarker( const std::string& frame, const std::string& ns, vis
 
 }
 
-const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_msgs::Wrench& wrench, const ros::Time& time, const geometry_msgs::Point& pos )
+const visualization_msgs::MarkerArray& WrenchMarker::getMarker( const geometry_msgs::WrenchStamped& wrench_stamped, const ros::Time& time )
+{
+
+  return getMarker( wrench_stamped.wrench, wrench_stamped.header.frame_id, geometry_msgs::Point(), time );
+
+}
+
+const visualization_msgs::MarkerArray& WrenchMarker::getMarker( const geometry_msgs::Wrench& wrench, const std::string& frame, const geometry_msgs::Point& pos, const ros::Time& time )
 {
 
   msg_->markers[0].header.stamp = time;
+  msg_->markers[0].header.frame_id = frame;
   msg_->markers[0].points[0].x = pos.x;
   msg_->markers[0].points[0].y = pos.y;
   msg_->markers[0].points[0].z = pos.z;
@@ -83,6 +90,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[0].points[1].z = pos.z + FORCE_ARROW_SCALE * wrench.force.z;
 
   msg_->markers[1].header.stamp = time;
+  msg_->markers[1].header.frame_id = frame;
   msg_->markers[1].points[0].x = pos.x;
   msg_->markers[1].points[0].y = pos.y + TORQUE_ARROW_SEPARATION/2;
   msg_->markers[1].points[0].z = pos.z - TORQUE_ARROW_SCALE * wrench.torque.x;
@@ -91,6 +99,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[1].points[1].z = pos.z + TORQUE_ARROW_SCALE * wrench.torque.x;
 
   msg_->markers[2].header.stamp = time;
+  msg_->markers[2].header.frame_id = frame;
   msg_->markers[2].points[0].x = pos.x;
   msg_->markers[2].points[0].y = pos.y - TORQUE_ARROW_SEPARATION/2;
   msg_->markers[2].points[0].z = pos.z + TORQUE_ARROW_SCALE * wrench.torque.x;
@@ -99,6 +108,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[2].points[1].z = pos.z - TORQUE_ARROW_SCALE * wrench.torque.x;
 
   msg_->markers[3].header.stamp = time;
+  msg_->markers[3].header.frame_id = frame;
   msg_->markers[3].points[0].x = pos.x - TORQUE_ARROW_SCALE * wrench.torque.y;
   msg_->markers[3].points[0].y = pos.y;
   msg_->markers[3].points[0].z = pos.z + TORQUE_ARROW_SEPARATION/2;
@@ -107,6 +117,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[3].points[1].z = pos.z + TORQUE_ARROW_SEPARATION/2;
 
   msg_->markers[4].header.stamp = time;
+  msg_->markers[4].header.frame_id = frame;
   msg_->markers[4].points[0].x = pos.x + TORQUE_ARROW_SCALE * wrench.torque.y;
   msg_->markers[4].points[0].y = pos.y;
   msg_->markers[4].points[0].z = pos.z - TORQUE_ARROW_SEPARATION/2;
@@ -115,6 +126,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[4].points[1].z = pos.z - TORQUE_ARROW_SEPARATION/2;
 
   msg_->markers[5].header.stamp = time;
+  msg_->markers[5].header.frame_id = frame;
   msg_->markers[5].points[0].x = pos.x + TORQUE_ARROW_SEPARATION/2;
   msg_->markers[5].points[0].y = pos.y - TORQUE_ARROW_SCALE * wrench.torque.z;
   msg_->markers[5].points[0].z = pos.z;
@@ -123,6 +135,7 @@ const visualization_msgs::MarkerArray& WrenchMarker::populate( const geometry_ms
   msg_->markers[5].points[1].z = pos.z;
 
   msg_->markers[6].header.stamp = time;
+  msg_->markers[6].header.frame_id = frame;
   msg_->markers[6].points[0].x = pos.x - TORQUE_ARROW_SEPARATION/2;
   msg_->markers[6].points[0].y = pos.y + TORQUE_ARROW_SCALE * wrench.torque.z;
   msg_->markers[6].points[0].z = pos.z;

--- a/src/wrench_marker_publisher.cpp
+++ b/src/wrench_marker_publisher.cpp
@@ -11,7 +11,7 @@
 
 #include <wrench_marker/wrench_marker.h>
 
-#include <geometry_msgs/Wrench.h>
+#include <geometry_msgs/WrenchStamped.h>
 
 #include <ros/ros.h>
 
@@ -27,14 +27,7 @@ public:
   WrenchMarkerPublisher()
   {
 
-    ros::NodeHandle p_nh("~");
-    if( !p_nh.getParam( "wrench_marker_frame", _wrench_marker_frame ) )
-    {
-      ROS_WARN( "Could not read 'wrench_marker_frame' parameter. Using 'world' as reference for the marker" );
-      _wrench_marker_frame = "world";
-    }
-
-    _wrench_marker.reset( new wrench_marker::WrenchMarker( _wrench_marker_frame ) );
+    _wrench_marker.reset( new wrench_marker::WrenchMarker );
 
     _wrench_sub = _nh.subscribe( "wrench", 1, &WrenchMarkerPublisher::wrench_cb, this );
     _wrench_marker_pub = _nh.advertise<visualization_msgs::MarkerArray>( "wrench_marker", 1 );
@@ -43,11 +36,10 @@ public:
 
 private:
 
-  void wrench_cb( const geometry_msgs::WrenchConstPtr& wrench_msg )
+  void wrench_cb( const geometry_msgs::WrenchStampedConstPtr& wrench_msg )
   {
 
-    const visualization_msgs::MarkerArray& wrench_marker_msg = _wrench_marker->populate( *wrench_msg );
-    _wrench_marker_pub.publish( wrench_marker_msg );
+    _wrench_marker_pub.publish( _wrench_marker->getMarker( *wrench_msg ) );
 
   }
 

--- a/src/wrench_marker_publisher.cpp
+++ b/src/wrench_marker_publisher.cpp
@@ -6,7 +6,7 @@
  * Copyright 2016 Tecnalia Research & Innovation.
  * Distributed under the GNU GPL v3. For full terms see https://www.gnu.org/licenses/gpl.txt
  *
- * @brief  Node which listens to geometry_msgs/Wrench messages and publishes markers to visualize in rviz.
+ * @brief  Node which listens to geometry_msgs/WrenchStamped messages and publishes markers to visualize in rviz.
  */
 
 #include <wrench_marker/wrench_marker.h>


### PR DESCRIPTION
Library can now generate markers with the same arguments as before, but can
also generate the markers from a single stamped wrench marker.

The node now subscribes to stamped wrench messages and does not require the
wrench_marker_frame parameter.
- [x] Check whether it correctly addreses #2 (@aremazeilles, could you do this?)
- [x] Update README
