### PR TITLE
Scale options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ The responsibility of publishing the message lies in user code.
 
 The `wrench_marker_publisher` node subscribes to `geometry_msgs/WrenchStamped` messages in the `wrench` topic, and publishes a marker array to visualize it in `wrench_marker` topic.
 
-To run it with a different input topic, run.
+The generated marker can be uniformly scaled by setting the private `wrench_marker_scale` parameter.
+
+To run it with a different input topic and/or scaling factor run.
 
 ```bash
-rosrun wrench_marker wrench_marker_publisher wrench:=INPUT_TOPIC
+rosrun wrench_marker wrench_marker_publisher wrench:=INPUT_TOPIC _wrench_marker_scale:=SCALING_FACTOR
 ```
 
 ## `wrench_marker` library basic usage
@@ -32,7 +34,7 @@ Sample code for how to use the `wrench_marker` library follows.
 
 int main( int argc, char** argv )
 {
-  wrench_marker::WrenchMarker my_wrench_marker();
+  wrench_marker::WrenchMarker my_wrench_marker;
 
   geometry_msgs::WrenchStamped wrench_msg;
   // Fill wrench data
@@ -51,11 +53,13 @@ A more ellaborate use-case can be found in [`wrench_marker_publisher.cpp`](src/w
 The full signature of the constructor is:
 
 ```c++
-WrenchMarker::WrenchMarker( 
+WrenchMarker::WrenchMarker(
+  const WrenchMarkerScaleOptions scale_options = WrenchMarkerScaleOptions();
   const std::string& ns = "wrench",
   visualization_msgs::MarkerArray* msg = 0 );
 ```
 
+- `scale_options` is an structure which can be used to control the scaling/positioning of the different arrows in the generated marker
 - `ns` is the namespace for the markers
 - `msg` is a pre-allocated `MarkerArray` message for internal use<sup>1</sup>
 

--- a/include/wrench_marker/wrench_marker.h
+++ b/include/wrench_marker/wrench_marker.h
@@ -19,20 +19,31 @@
 namespace wrench_marker
 {
 
-const double ARROW_SHAFT_DIAMETER = 0.01;
-const double ARROW_HEAD_DIAMETER = 0.02;
+struct WrenchMarkerScaleOptions
+{
 
-const double FORCE_ARROW_SCALE = 0.1;
+  WrenchMarkerScaleOptions( double scale = 1.0 )
+    : arrow_shaft_diameter( scale*0.1 )
+    , arrow_head_diameter( scale*0.2 )
+    , force_arrow_scale( scale )
+    , torque_arrow_scale( scale )
+    , torque_arrow_separation( scale )
+  {}
 
-const double TORQUE_ARROW_SCALE = 0.1;
-const double TORQUE_ARROW_SEPARATION = 0.1;
+  double arrow_shaft_diameter;
+  double arrow_head_diameter;
+  double force_arrow_scale;
+  double torque_arrow_scale;
+  double torque_arrow_separation;
+
+};
 
 class WrenchMarker
 {
 
 public:
 
-  WrenchMarker( const std::string& ns = "wrench", visualization_msgs::MarkerArray* msg = 0 );
+  WrenchMarker( const WrenchMarkerScaleOptions& scale_options = WrenchMarkerScaleOptions(), const std::string& ns = "wrench", visualization_msgs::MarkerArray* msg = 0 );
 
   const visualization_msgs::MarkerArray& getMarker( const geometry_msgs::WrenchStamped& wrench_stamped, const ros::Time& time = ros::Time::now() );
 
@@ -41,6 +52,8 @@ public:
 private:
 
   visualization_msgs::MarkerArray* msg_;
+
+  WrenchMarkerScaleOptions scale_options_;
 
 };
 

--- a/src/wrench_marker.cpp
+++ b/src/wrench_marker.cpp
@@ -14,8 +14,9 @@
 namespace wrench_marker
 {
 
-WrenchMarker::WrenchMarker( const std::string& ns, visualization_msgs::MarkerArray* msg )
-  : msg_( msg )
+WrenchMarker::WrenchMarker( const WrenchMarkerScaleOptions& scale_options, const std::string& ns, visualization_msgs::MarkerArray* msg )
+  : scale_options_( scale_options )
+  , msg_( msg )
 {
 
   if( msg_ )
@@ -32,8 +33,8 @@ WrenchMarker::WrenchMarker( const std::string& ns, visualization_msgs::MarkerArr
   aux_marker.id = 0;
   aux_marker.type = visualization_msgs::Marker::ARROW;
   aux_marker.action = visualization_msgs::Marker::ADD;
-  aux_marker.scale.x = ARROW_SHAFT_DIAMETER;
-  aux_marker.scale.y = ARROW_HEAD_DIAMETER;
+  aux_marker.scale.x = scale_options_.arrow_shaft_diameter;
+  aux_marker.scale.y = scale_options_.arrow_head_diameter;
   aux_marker.color.r = 1.0;
   aux_marker.color.g = 0.0;
   aux_marker.color.b = 1.0;
@@ -85,62 +86,62 @@ const visualization_msgs::MarkerArray& WrenchMarker::getMarker( const geometry_m
   msg_->markers[0].points[0].x = pos.x;
   msg_->markers[0].points[0].y = pos.y;
   msg_->markers[0].points[0].z = pos.z;
-  msg_->markers[0].points[1].x = pos.x + FORCE_ARROW_SCALE * wrench.force.x;
-  msg_->markers[0].points[1].y = pos.y + FORCE_ARROW_SCALE * wrench.force.y;
-  msg_->markers[0].points[1].z = pos.z + FORCE_ARROW_SCALE * wrench.force.z;
+  msg_->markers[0].points[1].x = pos.x + scale_options_.force_arrow_scale * wrench.force.x;
+  msg_->markers[0].points[1].y = pos.y + scale_options_.force_arrow_scale * wrench.force.y;
+  msg_->markers[0].points[1].z = pos.z + scale_options_.force_arrow_scale * wrench.force.z;
 
   msg_->markers[1].header.stamp = time;
   msg_->markers[1].header.frame_id = frame;
   msg_->markers[1].points[0].x = pos.x;
-  msg_->markers[1].points[0].y = pos.y + TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[1].points[0].z = pos.z - TORQUE_ARROW_SCALE * wrench.torque.x;
+  msg_->markers[1].points[0].y = pos.y + scale_options_.torque_arrow_separation/2;
+  msg_->markers[1].points[0].z = pos.z - scale_options_.torque_arrow_scale * wrench.torque.x;
   msg_->markers[1].points[1].x = pos.x;
-  msg_->markers[1].points[1].y = pos.y + TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[1].points[1].z = pos.z + TORQUE_ARROW_SCALE * wrench.torque.x;
+  msg_->markers[1].points[1].y = pos.y + scale_options_.torque_arrow_separation/2;
+  msg_->markers[1].points[1].z = pos.z + scale_options_.torque_arrow_scale * wrench.torque.x;
 
   msg_->markers[2].header.stamp = time;
   msg_->markers[2].header.frame_id = frame;
   msg_->markers[2].points[0].x = pos.x;
-  msg_->markers[2].points[0].y = pos.y - TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[2].points[0].z = pos.z + TORQUE_ARROW_SCALE * wrench.torque.x;
+  msg_->markers[2].points[0].y = pos.y - scale_options_.torque_arrow_separation/2;
+  msg_->markers[2].points[0].z = pos.z + scale_options_.torque_arrow_scale * wrench.torque.x;
   msg_->markers[2].points[1].x = pos.x;
-  msg_->markers[2].points[1].y = pos.y - TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[2].points[1].z = pos.z - TORQUE_ARROW_SCALE * wrench.torque.x;
+  msg_->markers[2].points[1].y = pos.y - scale_options_.torque_arrow_separation/2;
+  msg_->markers[2].points[1].z = pos.z - scale_options_.torque_arrow_scale * wrench.torque.x;
 
   msg_->markers[3].header.stamp = time;
   msg_->markers[3].header.frame_id = frame;
-  msg_->markers[3].points[0].x = pos.x - TORQUE_ARROW_SCALE * wrench.torque.y;
+  msg_->markers[3].points[0].x = pos.x - scale_options_.torque_arrow_scale * wrench.torque.y;
   msg_->markers[3].points[0].y = pos.y;
-  msg_->markers[3].points[0].z = pos.z + TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[3].points[1].x = pos.x + TORQUE_ARROW_SCALE * wrench.torque.y;
+  msg_->markers[3].points[0].z = pos.z + scale_options_.torque_arrow_separation/2;
+  msg_->markers[3].points[1].x = pos.x + scale_options_.torque_arrow_scale * wrench.torque.y;
   msg_->markers[3].points[1].y = pos.y;
-  msg_->markers[3].points[1].z = pos.z + TORQUE_ARROW_SEPARATION/2;
+  msg_->markers[3].points[1].z = pos.z + scale_options_.torque_arrow_separation/2;
 
   msg_->markers[4].header.stamp = time;
   msg_->markers[4].header.frame_id = frame;
-  msg_->markers[4].points[0].x = pos.x + TORQUE_ARROW_SCALE * wrench.torque.y;
+  msg_->markers[4].points[0].x = pos.x + scale_options_.torque_arrow_scale * wrench.torque.y;
   msg_->markers[4].points[0].y = pos.y;
-  msg_->markers[4].points[0].z = pos.z - TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[4].points[1].x = pos.x - TORQUE_ARROW_SCALE * wrench.torque.y;
+  msg_->markers[4].points[0].z = pos.z - scale_options_.torque_arrow_separation/2;
+  msg_->markers[4].points[1].x = pos.x - scale_options_.torque_arrow_scale * wrench.torque.y;
   msg_->markers[4].points[1].y = pos.y;
-  msg_->markers[4].points[1].z = pos.z - TORQUE_ARROW_SEPARATION/2;
+  msg_->markers[4].points[1].z = pos.z - scale_options_.torque_arrow_separation/2;
 
   msg_->markers[5].header.stamp = time;
   msg_->markers[5].header.frame_id = frame;
-  msg_->markers[5].points[0].x = pos.x + TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[5].points[0].y = pos.y - TORQUE_ARROW_SCALE * wrench.torque.z;
+  msg_->markers[5].points[0].x = pos.x + scale_options_.torque_arrow_separation/2;
+  msg_->markers[5].points[0].y = pos.y - scale_options_.torque_arrow_scale * wrench.torque.z;
   msg_->markers[5].points[0].z = pos.z;
-  msg_->markers[5].points[1].x = pos.x + TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[5].points[1].y = pos.y + TORQUE_ARROW_SCALE * wrench.torque.z;
+  msg_->markers[5].points[1].x = pos.x + scale_options_.torque_arrow_separation/2;
+  msg_->markers[5].points[1].y = pos.y + scale_options_.torque_arrow_scale * wrench.torque.z;
   msg_->markers[5].points[1].z = pos.z;
 
   msg_->markers[6].header.stamp = time;
   msg_->markers[6].header.frame_id = frame;
-  msg_->markers[6].points[0].x = pos.x - TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[6].points[0].y = pos.y + TORQUE_ARROW_SCALE * wrench.torque.z;
+  msg_->markers[6].points[0].x = pos.x - scale_options_.torque_arrow_separation/2;
+  msg_->markers[6].points[0].y = pos.y + scale_options_.torque_arrow_scale * wrench.torque.z;
   msg_->markers[6].points[0].z = pos.z;
-  msg_->markers[6].points[1].x = pos.x - TORQUE_ARROW_SEPARATION/2;
-  msg_->markers[6].points[1].y = pos.y - TORQUE_ARROW_SCALE * wrench.torque.z;
+  msg_->markers[6].points[1].x = pos.x - scale_options_.torque_arrow_separation/2;
+  msg_->markers[6].points[1].y = pos.y - scale_options_.torque_arrow_scale * wrench.torque.z;
   msg_->markers[6].points[1].z = pos.z;
 
   return *msg_;

--- a/src/wrench_marker_publisher.cpp
+++ b/src/wrench_marker_publisher.cpp
@@ -27,7 +27,15 @@ public:
   WrenchMarkerPublisher()
   {
 
-    _wrench_marker.reset( new wrench_marker::WrenchMarker );
+    ros::NodeHandle p_nh("~");
+    double wrench_marker_scale;
+    if( !p_nh.getParam( "wrench_marker_scale", wrench_marker_scale ) )
+    {
+      ROS_WARN( "Could not read 'wrench_marker_scale' parameter. Using 1.0 as default value" );
+      wrench_marker_scale = 1.0;
+    }
+
+    _wrench_marker.reset( new wrench_marker::WrenchMarker( wrench_marker::WrenchMarkerScaleOptions( wrench_marker_scale ) ) );
 
     _wrench_sub = _nh.subscribe( "wrench", 1, &WrenchMarkerPublisher::wrench_cb, this );
     _wrench_marker_pub = _nh.advertise<visualization_msgs::MarkerArray>( "wrench_marker", 1 );


### PR DESCRIPTION
Add WrenchMarkerScaleOptions and take it as an optional WrenchMarker constructor parameter to be able to adjust the position/size of the resulting marker.

This structure can be scaled uniformly (w/ respect to default values) by constructing it with a `double`, and all of its members can be manually tweaked for greater control.

Also added a general scaling parameter to the ROS node, to control the overall scaling of the published marker.

Care to review, @aremazeilles?
